### PR TITLE
9-3. python-AWS S3 연결을 위한 AWS_boto.md 작성

### DIFF
--- a/AI/AWS_boto.md
+++ b/AI/AWS_boto.md
@@ -1,0 +1,46 @@
+# AWS 연결하여 boto 사용하기
+
+## boto ?
+AWS 서비스를 파이썬에서 간편하게 활용할 수 있도록 제공해주는 SDK
+
+#### 권한 부여 
+Root 사용자로부터 IAM 사용자는 다음 권한을 받아야 한다. 
+
+```
+AmazonRekognitionFullAccess
+AmazonS3FullAccess 
+```
+
+
+#### CLI 설치 및 CLI 계정 설정 
+
+1.자신의 환경에 맞추어 설치한다.
+[Click! AWS CLI 설치](https://docs.aws.amazon.com/ko_kr/cli/latest/userguide/install-cliv2.html)
+
+
+<br />
+2. cli가 설치되었는지 터미널에 명령어를 입력하여 확인한다.
+
+`$ aws --version`
+버전 정보가 뜬다면, aws cli가 정상적으로 설치된 것이다. 
+
+<br />
+3. aws configure를 설정한다.
+
+`$ aws configure --profile {이름}`
+  
+IAM 사용자의 access key, secret key, region name을 입력한다. 
+
+cf ) configure 확인하는 방법 
+`$ aws configure list`
+
+<br />
+
+#### 접근 가능한 S3 확인하기
+AWS rekognition 수행 시 접근할 S3 bucket 정보가 뜬다면 AWS boto를 이용할 준비가 완료된 것이다 !  
+`$ aws s3 ls`
+
+<br />
+
+#### boto3 설치 (requirements.txt를 설치하지 않은 경우, 꼭 boto3를 설치해야 한다. )
+`$ pip install boto3`

--- a/AI/README.md
+++ b/AI/README.md
@@ -25,10 +25,9 @@ $ activate venv
 <br />
 
 
-### 3. root 폴더에 .env 파일 생성 후, key 넣기
-(아직 넣을 일 없지만, api 가져올 때 필수 !)
-<br />
-<br />
+### 3. AWS boto를 위해 계정 연결하기 
+
+[Click! go to AWS boto 계정 설정 방법](https://github.com/DA-sc21/test-helper/tree/main/AI/AWS_boto.md)
 
 
 ### 4. flask 실행하기

--- a/AI/requirements.txt
+++ b/AI/requirements.txt
@@ -1,3 +1,4 @@
 flask
 python-dotenv
 requests
+boto3


### PR DESCRIPTION
python의 경우 AWS CLI를 다운로드 받아 계정을 설정한 뒤, boto3 sdk를 설치만 하면 S3 등과 연결이 가능하므로, 
python에서의 boto 사용 전 해야할 일에 대해 정리해놓았습니다 !