### PR TITLE
10-2 account_id & test_status를 통해 요청하도록 수정

### DIFF
--- a/backend/testhelper/build.gradle
+++ b/backend/testhelper/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
 	//aws
 	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')

--- a/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/account/AccountMapper.java
+++ b/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/account/AccountMapper.java
@@ -1,0 +1,15 @@
+package kr.ac.ajou.da.testhelper.account;
+
+import java.sql.SQLException;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.springframework.stereotype.Repository;
+
+@Mapper
+@Repository
+public interface AccountMapper {
+	@Select("SELECT role FROM ACCOUNT WHERE id = ${accountId}")
+	String getAccountRole(@Param("accountId") int accountId) throws SQLException;
+}

--- a/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsController.java
+++ b/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsController.java
@@ -14,7 +14,7 @@ public class TestsController {
 	private TestsService testsService;
 	    
     @GetMapping("/tests")
-    public List<HashMap<String, Object>> getTests(@RequestParam int accountId, @RequestParam String accountRole, @RequestParam String testStatus) throws Exception {
-    	return testsService.getTests(accountId, accountRole, testStatus);
+    public List<HashMap<String, Object>> getTests(@RequestParam int accountId, @RequestParam String testStatus) throws Exception {
+    	return testsService.getTests(accountId, testStatus);
     }
 }

--- a/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsMapper.java
+++ b/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsMapper.java
@@ -12,6 +12,19 @@ import org.springframework.stereotype.Repository;
 @Mapper
 @Repository
 public interface TestsMapper {
-	@Select("SELECT * FROM COURSE JOIN TEST ON COURSE.id = TEST.course_id WHERE COURSE.professor_id = ${accountId} AND TEST.test_status = ${testStatus}")
-	List<HashMap<String, Object>> getTestList(@Param("accountId") int accountId,@Param("accountRole") String accountRole,@Param("testStatus") String testStatus) throws SQLException;
+	@Select("SELECT COURSE.name, TEST.id, TEST.test_type, TEST.start_time, TEST.end_time, TEST.test_status \n"
+			+ "FROM TEST \n"
+			+ "JOIN COURSE \n"
+			+ "ON TEST.course_id = COURSE.id \n"
+			+ "WHERE COURSE.professor_id = ${accountId} AND TEST.test_status = ${testStatus}")
+	List<HashMap<String, Object>> getTestListOfProfessor(@Param("accountId") int accountId, @Param("testStatus") String testStatus) throws SQLException;
+
+	@Select("SELECT COURSE.name, TEST.id, TEST.test_type, TEST.start_time, TEST.end_time, TEST.test_status \n"
+			+ "FROM TEST_ASSISTANT \n"
+			+ "JOIN TEST \n"
+			+ "ON TEST.id = TEST_ASSISTANT.test_id \n"
+			+ "JOIN COURSE \n"
+			+ "ON COURSE.id = TEST.course_id \n"
+			+ "WHERE TEST_ASSISTANT.account_id = ${accountId} AND TEST.test_status = ${testStatus}")
+	List<HashMap<String, Object>> getTestListOfAssistant(@Param("accountId") int accountId, @Param("testStatus") String testStatus) throws SQLException;
 }

--- a/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsService.java
+++ b/backend/testhelper/src/main/java/kr/ac/ajou/da/testhelper/tests/TestsService.java
@@ -7,12 +7,28 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import kr.ac.ajou.da.testhelper.account.AccountMapper;
+
 @Service
 public class TestsService {
 	@Autowired
 	private TestsMapper testsMapper;
+	@Autowired
+	private AccountMapper accountMapper;
 	
-	public List<HashMap<String, Object>> getTests(int accountId, String accountRole, String testStatus) throws SQLException {
-		return testsMapper.getTestList(accountId, accountRole, testStatus);
+	public List<HashMap<String, Object>> getTests(int accountId, String testStatus) throws SQLException {
+		String role = getAccountRole(accountId);
+		
+		if(role.equals("PROFESSOR")) {
+			return testsMapper.getTestListOfProfessor(accountId, testStatus);
+		} else if(role.equals("ASSISTANT")) {
+			return testsMapper.getTestListOfAssistant(accountId, testStatus);
+		}
+		
+		return null;
+	}
+
+	private String getAccountRole(int accountId) throws SQLException {
+		return accountMapper.getAccountRole(accountId);
 	}
 }


### PR DESCRIPTION
교수님 & 조교님의 시험 목록 요청 api 입니다

@leeshyeon 기존에서 조금 수정되었습니다!

실시할 시험 목록 조회의 경우 (MARK)
http://localhost:8081/tests?accountId=1&testStatus="MARK"
일단은 이런식으로 요청하시면 됩니다 !
