### PR TITLE
2-15 set default profile to prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: data-server:latest
     environment :
       - AWS_PROFILE=test-helper
-      - ENV_PROFILE=${PROFILE}
+      - ENV_PROFILE=${PROFILE:-prod}
     ports:
       - 8081:8081
     volumes:

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 if [ -d docker-compose.yml ]; then
-    docker-compose --env-file ./profile-prod.txt up --build
+    docker-compose up --build
 fi


### PR DESCRIPTION
문제 : 
 - server에서 docker-compose에 --env-file이 안됨
 
해결 방안 : 
- server에서 docker-compose up --build했을 때 default로 prod가 세팅되도록 수정

공지사항 : 
- server에서 docker 실행할 때 docker-compose up --build를 하면 됩니다!