### PR TITLE
6-1,6-3 카메라 및 마이크 공유 동의 선택 제거

### DIFF
--- a/frontend/src/student/TestStudentPre.js
+++ b/frontend/src/student/TestStudentPre.js
@@ -48,6 +48,7 @@ function TestStudentPre(){
       setStudent(result.data.room.student)
       setTest(result.data.room.test)
       setLoading(true);
+      console.log(result.data);
     })
     .catch(()=>{ console.log("실패") })
   }
@@ -72,23 +73,9 @@ function TestStudentPre(){
       <MobileView> 
         { mobileAgreement === false ? 
           <div style={{marginTop: '20%', marginLeft:'3%', marginRight: '3%'}}>
-            <p style={{marginBottom: '1%', fontSize: '20px', fontWeight: 'bold'}}>안녕하세요. O O O 시험</p>
-            <p style={{marginBottom: '20%', fontSize: '20px', fontWeight: 'bold'}}>응시 환경 세팅 "모바일" 화면입니다.</p>
-              <p style={{fontWeight: 'bold'}}>카메라 및 마이크 공유를 <span style={{ color: 'rgb(43, 73, 207)', fontWeight: 'bold'}}>모두 동의</span>한 후 설정완료 버튼을 클릭해주세요.</p>
-              <div style={{marginTop: '15%'}}>
-                <p style={{fontWeight: 'bold'}}>모바일 카메라 공유</p>
-                <div>
-                  <input type="checkbox" checked={video} onChange={(e) => changeVideo(e)}></input>
-                  <label>동의</label>
-                </div>
-              </div>
-              <div style={{marginTop: '10%', marginBottom: '20%'}}>
-                <p style={{fontWeight: 'bold'}}>모바일 마이크 공유</p>
-                <div>
-                  <input type="checkbox" checked={audio} onChange={(e) => changeAudio(e)}></input>
-                  <label> 동의</label>
-                </div>
-              </div>
+            <p style={{marginBottom: '1%', fontSize: '20px', fontWeight: 'bold'}}>{test.name}</p>
+            <p style={{marginBottom: '25%', fontSize: '20px', fontWeight: 'bold'}}>응시 환경 세팅 "모바일" 화면입니다.</p>
+              <p style={{fontWeight: 'bold', marginBottom:"20%"}}>화상회의 입장 시 카메라 및 마이크 공유를 <br/><span style={{ color: 'rgb(43, 73, 207)', fontWeight: 'bold'}}>모두 동의</span> 해주세요.</p>
             <Button 
               onClick={()=>{ 
                 console.log('Button clicked')
@@ -96,7 +83,7 @@ function TestStudentPre(){
                 history.push("/tests/"+testId+"/students/"+studentId+"/mobilesetting")
               }} 
               className="btn btn-primary" >
-              화상 회의 입장
+              화상회의 입장
             </Button> 
           </div>
           : null
@@ -111,8 +98,8 @@ function TestStudentPre(){
           credentials={credentials}
           student={student}
           room={room}
-          video={video}
-          audio={audio}
+          video={true}
+          audio={true}
         />
     </div>
   )


### PR DESCRIPTION
#### 기능

- 모바일 화면에서 OOO 시험 -> **시험 이름으로 변경**
- 모바일 화면에서 **카메라 및 마이크 공유 동의 선택 제거** (자동적으로 카메라 공유/마이크 공유 허용 팝업창 뜨기 때문)

#### 추후 고려사항
- 현재 카메라 및 마이크 공유 동의 선택이 제거되어 viewer kinesis 연결시 video, audio 값에 자체적으로 true값을 넣었습니다.
 (viewer가 팝업창에서 video 또는 audio를 허용하지 않아도, master에게는 모두 true 값으로 인식될 수 있습니다.)

#### 변경 화면

![image](https://user-images.githubusercontent.com/55876471/142632043-3689fea5-5cbf-489c-828e-80ce7ba04724.png)
